### PR TITLE
Allow `include` key to have yaml sequence

### DIFF
--- a/tzf/pyramid_yml/__init__.py
+++ b/tzf/pyramid_yml/__init__.py
@@ -182,8 +182,8 @@ def _run_includemes(configurator, includemes):
     :param dict includemes: include, a list of includes or dictionary
     """
     for include in includemes:
-        if includemes[include]:
-            try:
+        try:
+            if includemes[include]:
                 configurator.include(include, includemes[include])
-            except AttributeError:
-                configurator.include(include)
+        except (AttributeError, TypeError):
+            configurator.include(include)


### PR DESCRIPTION
`include` key can be either yaml sequence or yaml map.

This lets me replace:

``` yaml
include:
  smlib.traceback: True
  rattr: True
```

with the (IMHO) more natural:

``` yaml
include:
  - smlib.traceback
  - rattr
```

You probably want a test for this and I am a big TDD fan, but I had a little trouble figuring out how to do the test. Feel free to give me some guidance on how you'd like to do it; or if it's quicker for you to add the test yourself, that's cool too.
