### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,15 @@
 tzf.pyramid_yml README
 ==========================
 
-.. image:: https://pypip.in/v/tzf.pyramid_yml/badge.png
+.. image:: https://img.shields.io/pypi/v/tzf.pyramid_yml.svg
     :target: https://pypi.python.org/pypi/tzf.pyramid_yml/
     :alt: Latest PyPI version
 
-.. image:: https://pypip.in/d/tzf.pyramid_yml/badge.png
+.. image:: https://img.shields.io/pypi/dm/tzf.pyramid_yml.svg
     :target: https://pypi.python.org/pypi/tzf.pyramid_yml/
     :alt: Number of PyPI downloads
 
-.. image:: https://pypip.in/wheel/tzf.pyramid_yml/badge.png
+.. image:: https://img.shields.io/pypi/wheel/tzf.pyramid_yml.svg
     :target: https://pypi.python.org/pypi/tzf.pyramid_yml/
     :alt: Wheel Status
 
@@ -18,7 +18,7 @@ tzf.pyramid_yml README
     :target: https://pypi.python.org/pypi/tzf.pyramid_yml/
     :alt: Egg Status
 
-.. image:: https://pypip.in/license/tzf.pyramid_yml/badge.png
+.. image:: https://img.shields.io/pypi/l/tzf.pyramid_yml.svg
     :target: https://pypi.python.org/pypi/tzf.pyramid_yml/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20tzf-pyramid-yml))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `tzf-pyramid-yml`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.